### PR TITLE
add check connection count

### DIFF
--- a/options.go
+++ b/options.go
@@ -12,6 +12,7 @@ var (
 	errInvalid  = errors.New("invalid config")
 	errRejected = errors.New("connection is nil. rejecting")
 	errTargets  = errors.New("targets server is empty")
+	errTooMany  = errors.New("too many connections")
 )
 
 func init() {


### PR DESCRIPTION
1. 当初始化的链接都超过了空闲时间，当 `pool.Get` 时，会重新创建一个链接并返回。
  针对这个问题，新增了一个方法，在 `NewGRPCPool` 方法中调用，每隔 10s 中，维护一下连接池数量。
```
//check connection count
go pool.CheckGRPCPool()
```

2. 当初始化的链接数超过 MaxCap，比如做压测的时候。
  针对这个问题，新增了一个判断，当 `c.IdleCount() >= MaxCap` 时，会返回一个 Error。

3. 当 `pool.Get` 时，新增一个判断：
```
if wrapConn.conn.GetState() != connectivity.Ready {
	c.close(wrapConn.conn)
	continue
}
```